### PR TITLE
fixed issue for hitting enter to submit new ext client name

### DIFF
--- a/src/route/extclients/components/ExtClientEdit.tsx
+++ b/src/route/extclients/components/ExtClientEdit.tsx
@@ -105,6 +105,7 @@ export const ExtClientEdit: React.FC<{}> = () => {
               submitProps={{
                 variant: 'contained',
                 fullWidth: true,
+                type: 'submit',
               }}
             >
               <NmFormInputText


### PR DESCRIPTION
nm from on ext client edit was missing type making enter key to submit not work. 