### PR TITLE
added use effect to update filternetworks

### DIFF
--- a/src/route/networks/Networks.tsx
+++ b/src/route/networks/Networks.tsx
@@ -22,6 +22,7 @@ export const Networks: React.FC = () => {
   })
 
   // by updating the filterNetworks, the table will update
+  //useeffect tells says that setfilternetworks needs to do something, it sets list of networks to it then recalls it after the list of networks has been updated causing the table to update
   React.useEffect(() => {
     setFilterNetworks(listOfNetworks)
   }, [listOfNetworks])

--- a/src/route/networks/Networks.tsx
+++ b/src/route/networks/Networks.tsx
@@ -21,6 +21,11 @@ export const Networks: React.FC = () => {
     title: t('breadcrumbs.networks'),
   })
 
+  // by updating the filterNetworks, the table will update
+  React.useEffect(() => {
+    setFilterNetworks(listOfNetworks)
+  }, [listOfNetworks])
+
   const handleFilter = (event: { target: { value: string } }) => {
     const { value } = event.target
     const searchTerm = value.trim()
@@ -46,11 +51,11 @@ export const Networks: React.FC = () => {
             alignItems="center"
           >
             <Grid item xs={8} md={5}>
-              <div style={{textAlign: "center"}}>
-              <h2>{t('network.networks')}</h2>
+              <div style={{ textAlign: 'center' }}>
+                <h2>{t('network.networks')}</h2>
               </div>
             </Grid>
-            <Grid item xs={10} md={5} style={{textAlign: "center"}}>
+            <Grid item xs={10} md={5} style={{ textAlign: 'center' }}>
               <Grid container justifyContent="space-around" alignItems="center">
                 <Grid item xs={6} md={5}>
                   <TextField


### PR DESCRIPTION
By updating the filter with a use effect it causes the table to update as well. This fixes the network create not working on first load.