### PR TITLE
add defaultinterface field to host

### DIFF
--- a/src/i18n/resources/en.ts
+++ b/src/i18n/resources/en.ts
@@ -135,6 +135,7 @@ export const en: LanguageResource = {
     hosts: 'Hosts',
   },
   common: {
+    defaultinterface: 'Default Interface',
     host: 'Host',
     endpointip: 'Endpoint IP',
     connecttonetwork: 'Connect to network',

--- a/src/route/hosts/HostDetailPage.tsx
+++ b/src/route/hosts/HostDetailPage.tsx
@@ -253,13 +253,13 @@ export const HostDetailPage: FC = () => {
                   label={String(t('common.internetgateway'))}
                 />
               </Grid>
-              {/* <Grid item xs={12} md={3} sx={rowMargin}>
+              <Grid item xs={12} md={3} sx={rowMargin}>
                 <TextField
                   disabled
-                  value={host.firewallinuse}
-                  label={String(t('common.firewallinuse'))}
+                  value={host.defaultinterface}
+                  label={String(t('common.defaultinterface'))}
                 />
-              </Grid> */}
+              </Grid>
               <Grid item xs={12} md={3} sx={rowMargin}>
                 <TextField
                   disabled

--- a/src/route/hosts/HostEditPage.tsx
+++ b/src/route/hosts/HostEditPage.tsx
@@ -17,6 +17,7 @@ import { useLinkBreadcrumb } from '~components/PathBreadcrumbs'
 import { Host } from '~store/types'
 import { useGetHostById } from '~util/hosts'
 import { updateHost } from '~store/modules/hosts/actions'
+import { NmFormOptionSelect } from '~components/form/FormOptionSelect'
 
 export const HostEditPage: FC<{ onCancel: () => void }> = ({ onCancel }) => {
   const { url } = useRouteMatch()
@@ -154,17 +155,6 @@ export const HostEditPage: FC<{ onCancel: () => void }> = ({ onCancel }) => {
             </span>
           </Tooltip>
         </Grid>
-        {/* <Grid item xs={12} md={3} sx={rowMargin}>
-          <Tooltip title={String(t('common.localrange'))}>
-            <span>
-              <NmFormInputText
-                defaultValue={host.localrange}
-                name={'localrange'}
-                label={String(t('common.localrange'))}
-              />
-            </span>
-          </Tooltip>
-        </Grid> */}
         <Grid item xs={12} md={3} sx={rowMargin}>
           <Tooltip title={String(t('common.listenport'))}>
             <span>
@@ -187,6 +177,21 @@ export const HostEditPage: FC<{ onCancel: () => void }> = ({ onCancel }) => {
                 type="number"
               />
             </span>
+          </Tooltip>
+        </Grid>
+        <Grid item xs={12} md={3} sx={rowMargin}>
+          <Tooltip title={String(t('common.defaultinterface'))} placement="top">
+            <NmFormOptionSelect
+              defaultValue={host.defaultinterface}
+              label={String(t('common.defaultinterface'))}
+              name="defaultinterface"
+              selections={
+                host.interfaces.map((iface) => ({
+                  key: `${iface.name} (${iface.addressString})`,
+                  option: iface.name,
+                })) ?? []
+              }
+            />
           </Tooltip>
         </Grid>
         <Grid item xs={12} md={3} sx={rowMargin}>

--- a/src/route/hosts/HostEditPage.tsx
+++ b/src/route/hosts/HostEditPage.tsx
@@ -1,9 +1,5 @@
 import { FC, useCallback, useMemo } from 'react'
-import {
-  Grid,
-  Typography,
-  Tooltip,
-} from '@mui/material'
+import { Grid, Typography, Tooltip } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 import { useRouteMatch, useParams } from 'react-router-dom'
 import { useDispatch } from 'react-redux'
@@ -186,10 +182,12 @@ export const HostEditPage: FC<{ onCancel: () => void }> = ({ onCancel }) => {
               label={String(t('common.defaultinterface'))}
               name="defaultinterface"
               selections={
-                host.interfaces.map((iface) => ({
-                  key: `${iface.name} (${iface.addressString})`,
-                  option: iface.name,
-                })) ?? []
+                [...new Set(host.interfaces.map((iface) => iface.name))].map(
+                  (ifaceName) => ({
+                    key: ifaceName,
+                    option: ifaceName,
+                  })
+                ) ?? []
               }
             />
           </Tooltip>

--- a/src/store/modules/hosts/types.ts
+++ b/src/store/modules/hosts/types.ts
@@ -20,6 +20,7 @@ export interface Host {
   proxy_listen_port: number
   mtu: number
   interfaces: Interface[]
+  defaultinterface: string // iface name
   endpointip: string
   publickey: string
   macaddress: string


### PR DESCRIPTION
TESTING STEPS:
1. Select a host
2. Check that you can view and edit the new default interface field
