### PR TITLE
fix(GRA-1259): fix host name validation

### DIFF
--- a/src/route/hosts/HostEditPage.tsx
+++ b/src/route/hosts/HostEditPage.tsx
@@ -34,7 +34,7 @@ export const HostEditPage: FC<{ onCancel: () => void }> = ({ onCancel }) => {
     () =>
       validate<Host>({
         name: (value, formData) => {
-          const nameRegex = /^[a-zA-Z0-9-]+$/
+          const nameRegex = /^[a-zA-Z0-9-.]+$/
           const message = t('error.name')
 
           if (!nameRegex.test(value)) return { message, type: 'value' }


### PR DESCRIPTION
TESTING STEPS:
1. Go to host edit page
2. Try to change the name of a host (add a period, '.')
3. Check that it works