### PR TITLE
fix(GRA-1470): fix enrolllment key search with spaces

### DIFF
--- a/src/route/enrollmentkeys/components/EnrollmentKeysTable.tsx
+++ b/src/route/enrollmentkeys/components/EnrollmentKeysTable.tsx
@@ -85,7 +85,7 @@ export const EnrollmentKeysTable: FC<EnrollmentKeysTableProps> = (props) => {
         .concat(key.networks)
         .join('')
         .toLocaleLowerCase()
-        .includes(searchFilter.toLocaleLowerCase())
+        .includes(searchFilter.toLocaleLowerCase().trim())
     )
   }, [searchFilter, tableData])
 
@@ -121,7 +121,7 @@ export const EnrollmentKeysTable: FC<EnrollmentKeysTableProps> = (props) => {
           label={t('common.search')}
           placeholder={t('common.searchbytag')}
           value={searchFilter}
-          onInput={(ev: any) => setSearchFilter(String(ev.target.value).trim())}
+          onInput={(ev: any) => setSearchFilter(String(ev.target.value))}
         />
       </Grid>
 


### PR DESCRIPTION
TESTING STEPS:
1. create an anrollment key with spaces in name. eg: "hello world"
2. search for the created key and check that it show

details here: [GRA-1470](https://toil.kitemaker.co/cQARgD-Gravitl/Nk7Fgo-Main_Board/items/1470)
