### PR TITLE
refactor refresh host keys

### DIFF
--- a/src/i18n/resources/en.ts
+++ b/src/i18n/resources/en.ts
@@ -135,6 +135,7 @@ export const en: LanguageResource = {
     hosts: 'Hosts',
   },
   common: {
+    refreshkeys: 'Refresh Keys',
     tagshitentertoaadd: 'Tags (hit enter to add)',
     networks: 'Networks',
     expireat: 'Expire At',
@@ -728,6 +729,9 @@ export const en: LanguageResource = {
     relayedby: 'Relayed By',
     canonlyrelaynonrelayedhosts: 'Can only relay non-relayed hosts',
     isstatic: 'Is Static',
+    refreshconfirm:
+      'Are you sure you want to reset the public & private key pairs of this host?',
+    refreshkeysfor: 'Refresh keys for',
   },
   enrollmentkeys: {
     nokeysavailable: 'No keys available',

--- a/src/route/hosts/components/HostsTable.tsx
+++ b/src/route/hosts/components/HostsTable.tsx
@@ -4,8 +4,11 @@ import { useTranslation } from 'react-i18next'
 import { NmTable, TableColumns } from '~components/Table'
 import CopyText from '~components/CopyText'
 import { Host } from '~store/modules/hosts/types'
-import { Grid, Switch, TextField, Typography } from '@mui/material'
+import { Grid, IconButton, Switch, TextField, Typography } from '@mui/material'
 import CustomizedDialogs from '~components/dialog/CustomDialog'
+import { Autorenew } from '@mui/icons-material'
+import { useDispatch } from 'react-redux'
+import { refreshHostKeys } from '~store/modules/hosts/actions'
 
 interface HostsTableProps {
   hosts: Host[]
@@ -14,9 +17,15 @@ interface HostsTableProps {
 
 export const HostsTable: FC<HostsTableProps> = (props) => {
   const { t } = useTranslation()
+  const dispatch = useDispatch()
+
   const [searchFilter, setSearchFilter] = useState('')
   const [shouldShowConfirmDefaultModal, setShouldShowConfirmDefaultModal] =
     useState(false)
+  const [
+    shouldShowConfirmRefreshKeysModal,
+    setShouldShowConfirmRefreshKeysModal,
+  ] = useState(false)
   const [targetHost, setTargetHost] = useState<Host | null>(null)
   const columns: TableColumns<Host> = [
     {
@@ -77,6 +86,16 @@ export const HostsTable: FC<HostsTableProps> = (props) => {
         </>
       ),
     },
+    {
+      id: 'id',
+      labelKey: 'common.refreshkeys',
+      minWidth: 50,
+      format: (value, host) => (
+        <IconButton onClick={() => openConfirmRefreshKeysModal(host)}>
+          <Autorenew />
+        </IconButton>
+      ),
+    },
   ]
 
   const filteredHosts = useMemo(() => {
@@ -100,6 +119,22 @@ export const HostsTable: FC<HostsTableProps> = (props) => {
   const hideConfirmDefaultModal = useCallback(() => {
     setShouldShowConfirmDefaultModal(false)
   }, [])
+
+  const openConfirmRefreshKeysModal = useCallback((host: Host) => {
+    setTargetHost(host)
+    setShouldShowConfirmRefreshKeysModal(true)
+  }, [])
+
+  const hideConfirmRefreshKeysModal = useCallback(() => {
+    setShouldShowConfirmRefreshKeysModal(false)
+  }, [])
+
+  const refreshKeys = useCallback(
+    (targetHost: Host) => {
+      dispatch(refreshHostKeys['request']({ id: targetHost.id }))
+    },
+    [dispatch]
+  )
 
   return (
     <>
@@ -152,6 +187,15 @@ export const HostsTable: FC<HostsTableProps> = (props) => {
           title={t('hosts.confirmdefaultness')}
         />
       ) : null}
+      {!!targetHost && (
+        <CustomizedDialogs
+          open={shouldShowConfirmRefreshKeysModal}
+          handleClose={hideConfirmRefreshKeysModal}
+          handleAccept={() => refreshKeys(targetHost)}
+          message={t('hosts.refreshconfirm')}
+          title={`${t('hosts.refreshkeysfor')} ${targetHost.name}`}
+        />
+      )}
     </>
   )
 }

--- a/src/route/networks/components/NetworkTable.tsx
+++ b/src/route/networks/components/NetworkTable.tsx
@@ -4,7 +4,7 @@ import { NmLink } from '~components/Link'
 import { Network } from '../../../store/modules/network'
 import { datePickerConverter } from '../../../util/unixTime'
 import { NmTable, TableColumns } from '~components/Table'
-import { Autorenew, Delete } from '@mui/icons-material'
+import { Delete } from '@mui/icons-material'
 import CopyText from '~components/CopyText'
 
 import { useTranslation } from 'react-i18next'
@@ -108,14 +108,6 @@ export const NetworkTable: React.FC<{ networks: Network[] }> = ({
         rows={networks}
         getRowId={(row) => row.netid}
         actions={[
-          (row) => ({
-            tooltip: `${t('network.refresh')} : ${row.netid}`,
-            disabled: false,
-            icon: <Autorenew />,
-            onClick: () => {
-              handleOpen(row.netid, true)
-            },
-          }),
           (row) => ({
             tooltip: t('common.delete'),
             disabled: false,

--- a/src/store/modules/hosts/actions.ts
+++ b/src/store/modules/hosts/actions.ts
@@ -6,6 +6,7 @@ import {
   UpdateHostNetworksPayload,
   DeleteHostRelayPayload,
   CreateHostRelayPayload,
+  RefreshHostKeysPayload,
 } from '.'
 
 export const getHosts = createAsyncAction(
@@ -30,6 +31,16 @@ export const updateHostNetworks = createAsyncAction(
   Error
 >()
 
+export const refreshHostKeys = createAsyncAction(
+  'Hosts_refreshHostKeys_Request',
+  'Hosts_refreshHostKeys_Success',
+  'Hosts_refreshHostKeys_Failure'
+)<
+  RefreshHostKeysPayload['Request'],
+  RefreshHostKeysPayload['Response'],
+  Error
+>()
+
 export const deleteHost = createAsyncAction(
   'Hosts_deleteHosts_Request',
   'Hosts_deleteHosts_Success',
@@ -40,12 +51,20 @@ export const createHostRelay = createAsyncAction(
   'Hosts_createHostRelay_Request',
   'Hosts_createHostRelay_Success',
   'Hosts_createHostRelay_Failure'
-)<CreateHostRelayPayload['Request'], CreateHostRelayPayload['Response'], Error>()
+)<
+  CreateHostRelayPayload['Request'],
+  CreateHostRelayPayload['Response'],
+  Error
+>()
 
 export const deleteHostRelay = createAsyncAction(
   'Hosts_deleteHostRelay_Request',
   'Hosts_deleteHostRelay_Success',
   'Hosts_deleteHostRelay_Failure'
-)<DeleteHostRelayPayload['Request'], DeleteHostRelayPayload['Response'], Error>()
+)<
+  DeleteHostRelayPayload['Request'],
+  DeleteHostRelayPayload['Response'],
+  Error
+>()
 
 export const clearHosts = createAction('Hosts_clearHosts')<string>()

--- a/src/store/modules/hosts/types.ts
+++ b/src/store/modules/hosts/types.ts
@@ -59,6 +59,11 @@ export interface UpdateHostPayload {
   Response: Host
 }
 
+export interface RefreshHostKeysPayload {
+  Request: { id: Host['id'] }
+  Response: void
+}
+
 export interface UpdateHostNetworksPayload {
   Request: {
     id: Host['id']


### PR DESCRIPTION
TESTING STEPS:
1. Check that user can no longer refresh keys from network level
2. Check that refreshing a particular host's keys is available from both hosts table and host details page
